### PR TITLE
[annotations] ensure labelLegend is used in PDF and portfolio annotation reports

### DIFF
--- a/src/Features/annotations/utils/getAnnotationTemplateProps.js
+++ b/src/Features/annotations/utils/getAnnotationTemplateProps.js
@@ -9,6 +9,7 @@ export default function getAnnotationTemplateProps(annotationTemplate) {
 
     image: annotationTemplate?.image,
     label: annotationTemplate?.label,
+    labelLegend: annotationTemplate?.labelLegend,
     meterByPx: annotationTemplate?.meterByPx,
 
     fillColor: annotationTemplate?.fillColor,

--- a/src/Features/pdfReport/utils/createAnnotationsPdfReport.js
+++ b/src/Features/pdfReport/utils/createAnnotationsPdfReport.js
@@ -11,11 +11,13 @@ export default async function createAnnotationsPdfReport(
   // helpers issues => items
 
   let items = annotations.map((annotation) => {
+    const templateProps = annotation.annotationTemplateProps;
     return {
       ...annotation,
       description: annotation.entity?.text || annotation.entity?.description,
       number: annotation.entity?.num ? Number(annotation.entity?.num) : "",
       imageUrl: annotation.entity?.image?.imageUrlClient,
+      label: templateProps?.labelLegend || templateProps?.label || annotation.label,
     };
   });
 

--- a/src/Features/portfolioEditor/utils/getPageAnnotationsWithDetails.js
+++ b/src/Features/portfolioEditor/utils/getPageAnnotationsWithDetails.js
@@ -64,16 +64,31 @@ export default async function getPageAnnotationsWithDetails(pageId) {
     .toArray();
   const listingsMap = getItemsByKey(listings, "id");
 
+  // fetch annotation templates for labelLegend resolution
+  const templateIds = [
+    ...new Set(visibleAnnotations.map((a) => a.annotationTemplateId).filter(Boolean)),
+  ];
+  const annotationTemplates = templateIds.length
+    ? await db.annotationTemplates.where("id").anyOf(templateIds).toArray()
+    : [];
+  const annotationTemplatesMap = getItemsByKey(annotationTemplates, "id");
+
   // hydrate entities with images
   const enriched = await Promise.all(
     visibleAnnotations.map(async (annotation) => {
       const table =
         annotation.listingTable ||
         listingsMap[annotation.listingId]?.table;
-      if (!table || !annotation.entityId) return annotation;
+
+      const template = annotationTemplatesMap[annotation.annotationTemplateId];
+      const annotationTemplateProps = template
+        ? { label: template.label, labelLegend: template.labelLegend }
+        : undefined;
+
+      if (!table || !annotation.entityId) return { ...annotation, annotationTemplateProps };
 
       const entity = await db[table].get(annotation.entityId);
-      if (!entity) return annotation;
+      if (!entity) return { ...annotation, annotationTemplateProps };
 
       const { entityWithImages, hasImages } =
         await getEntityWithImagesAsync(entity);
@@ -83,6 +98,7 @@ export default async function getPageAnnotationsWithDetails(pageId) {
         entity: entityWithImages,
         hasImages,
         label: entityWithImages?.label,
+        annotationTemplateProps,
       };
     })
   );


### PR DESCRIPTION
- Add labelLegend to getAnnotationTemplateProps so it is available via
  annotation.annotationTemplateProps.labelLegend in useAnnotationsV2
- Fetch annotation templates in getPageAnnotationsWithDetails and attach
  annotationTemplateProps (label + labelLegend) to each annotation for
  the portfolio PDF flow
- In createAnnotationsPdfReport use template labelLegend (then label)
  as the item label, falling back to the annotation's own label

https://claude.ai/code/session_01TqHVm47Y25Kn3THbExRLH5