### PR TITLE
[mapEditor] enhancements (#127)

### DIFF
--- a/src/Features/mapEditor/components/MainMapEditorV3.jsx
+++ b/src/Features/mapEditor/components/MainMapEditorV3.jsx
@@ -1211,7 +1211,7 @@ export default function MainMapEditorV3({ forViewerKey = "MAP" }) {
             <DialogAutoCreateEntity />
             <PopperEditAnnotation viewerKey={forViewerKey} />
             <PopperEditAnnotations viewerKey={forViewerKey} allAnnotations={annotations} />
-            <PopperEditScale />
+            <PopperEditScale viewerKey={forViewerKey} />
             <PopperContextMenu />
 
             {/* <DialogAutoMigrateToMapEditorV3 /> */}

--- a/src/Features/mapEditor/components/PopperEditScale.jsx
+++ b/src/Features/mapEditor/components/PopperEditScale.jsx
@@ -8,19 +8,23 @@ import useResetNewAnnotation from "Features/annotations/hooks/useResetNewAnnotat
 import PopperBox from "Features/layout/components/PopperBox";
 import SectionEditScale from "./SectionEditScale";
 
-export default function PopperEditScale() {
+export default function PopperEditScale({ viewerKey = null }) {
   const dispatch = useDispatch();
 
   // data
 
   const anchorPosition = useSelector((s) => s.mapEditor.anchorPositionScale);
   const scaleAnnotationId = useSelector((s) => s.mapEditor.scaleAnnotationId);
+  const activeViewerKey = useSelector((s) => s.viewers.selectedViewerKey);
 
   const resetNewAnnotation = useResetNewAnnotation();
 
   // helper
 
-  const open = Boolean(anchorPosition);
+  const shouldShow = viewerKey
+    ? activeViewerKey === viewerKey
+    : activeViewerKey === "MAP";
+  const open = shouldShow && Boolean(anchorPosition);
 
   // handlers
 

--- a/src/Features/mapEditor/components/PopperMapListings.jsx
+++ b/src/Features/mapEditor/components/PopperMapListings.jsx
@@ -65,9 +65,11 @@ import SectionSmartDetect from "Features/smartDetect/components/SectionSmartDete
 import SectionShortcutHelpers from "Features/annotations/components/SectionShortcutHelpers";
 import SectionLayers from "Features/layers/components/SectionLayers";
 import {
+  setShowLayers,
   setSoloVisibleTemplateIds,
   setSoloListingId,
 } from "Features/popperMapListings/popperMapListingsSlice";
+import useLayers from "Features/layers/hooks/useLayers";
 import { alpha } from "@mui/material/styles";
 import {
   setEnabledDrawingMode,
@@ -1272,10 +1274,18 @@ export default function PopperMapListings() {
   const showLayers = useSelector((s) => s.popperMapListings.showLayers);
 
   const baseMap = useMainBaseMap();
+  const layers = useLayers({ filterByBaseMapId: baseMap?.id });
   const showCalibration = useSelector(
     (s) => s.baseMapEditor.showCalibration
   );
   const versionsCount = baseMap?.versions?.length ?? 0;
+
+  // Auto-enable showLayers when baseMap has layers in MAP viewer
+  useEffect(() => {
+    if (viewerKey === "MAP") {
+      dispatch(setShowLayers(layers?.length > 0));
+    }
+  }, [layers?.length, viewerKey]);
 
   // single annotation source for all counts
   const allAnnotations = useAnnotationsV2({

--- a/src/Features/mapEditor/components/SectionEditScale.jsx
+++ b/src/Features/mapEditor/components/SectionEditScale.jsx
@@ -5,6 +5,8 @@ import { useSelector, useDispatch } from "react-redux";
 import {
   setAnchorPositionScale,
   setScaleAnnotationId,
+  setOrthoSnapAngleOffset,
+  setOrthoSnapEnabled,
 } from "../mapEditorSlice";
 import useUpdateEntity from "Features/entities/hooks/useUpdateEntity";
 import useMainBaseMapListing from "Features/baseMaps/hooks/useMainBaseMapListing";
@@ -15,6 +17,7 @@ import useDeleteAnnotation from "Features/annotations/hooks/useDeleteAnnotation"
 import useResetNewAnnotation from "Features/annotations/hooks/useResetNewAnnotation";
 
 import { Paper, Button, Typography, Box, TextField } from "@mui/material";
+import IconOrthoSnap from "Features/icons/IconOrthoSnap";
 
 import FieldTextV2 from "Features/form/components/FieldTextV2";
 import ButtonGeneric from "Features/layout/components/ButtonGeneric";
@@ -61,6 +64,10 @@ export default function SectionEditScale() {
   // helper - angle
 
   const angle = angleInRad * 180 / Math.PI;
+  let normalizedAngle = -angle;
+  while (normalizedAngle <= -90) normalizedAngle += 180;
+  while (normalizedAngle > 90) normalizedAngle -= 180;
+  normalizedAngle = Math.round(normalizedAngle * 100) / 100;
 
   // helper
 
@@ -98,6 +105,11 @@ export default function SectionEditScale() {
     });
   }
 
+  function handleSnapAngleClick() {
+    dispatch(setOrthoSnapAngleOffset(normalizedAngle));
+    dispatch(setOrthoSnapEnabled(true));
+  }
+
   return (
 
     <Box sx={{ width: 1 }}>
@@ -115,11 +127,17 @@ export default function SectionEditScale() {
         </BoxAlignToRight>
       </Box>
 
-      <Box sx={{ p: 0.5 }}>
+      <Box sx={{ p: 0.5, display: "flex", alignItems: "center", gap: 0.5 }}>
         <ButtonGeneric
           size="small"
-          label={angle.toFixed(2) + "°"}
+          label={normalizedAngle.toFixed(2) + "°"}
           onClick={handleAngleClick}
+        />
+        <ButtonGeneric
+          size="small"
+          label="Enregistrer comme angle principal"
+          startIcon={<IconOrthoSnap />}
+          onClick={handleSnapAngleClick}
         />
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- Auto-enable layers toggle when baseMap has layers in MAP viewer
- Fix PopperEditScale rendering in both MAP and BASE_MAPS viewers by conditioning on active viewer
- Add snap angle button in SectionEditScale to set orthoSnapAngleOffset from measured angle

Closes #127